### PR TITLE
fix(fileLoader): create empty remoteOpts

### DIFF
--- a/src/store/fileLoader.js
+++ b/src/store/fileLoader.js
@@ -134,7 +134,7 @@ export default ({ proxyManager, girder }) => ({
           Object.assign(fileState, {
             state: 'needsDownload',
             remoteURL: fileInfo.remoteURL,
-            remoteOpts: fileInfo.remoteOpts,
+            remoteOpts: fileInfo.remoteOpts || {},
             withGirderToken: !!fileInfo.withGirderToken,
           });
         }


### PR DESCRIPTION
An empty `remoteOpts` throws an error when assigning headers. Default remoteOpts to an empty object.

Closes #433.