### PR TITLE
chore: rename ParaView Glance to Glance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish website
         env:
-          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/Glance.git
+          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/glance.git
         run: npm run doc:publish
 
       - name: stable - remove worktree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,22 @@
-Contributing to ParaView Glance
+Contributing to Glance
 ================================
 
-This page documents at a very high level how to contribute to ParaView Glance Viewer.
+This page documents at a very high level how to contribute to the Glance Viewer.
 
-1. The ParaView Glance Viewer source is maintained on Github at [github.com/kitware/Glance](https://github.com/kitware/Glance)
+1. Glance's source is maintained on Github at [github.com/kitware/glance](https://github.com/kitware/glance)
 
-2. [Fork ParaView Glance] into your user's namespace on Github.
+2. [Fork Glance] into your user's namespace on Github.
 
 3. Create a local clone of the main repository:
 
     ```sh
-    $ git clone https://github.com/kitware/Glance.git
+    $ git clone https://github.com/kitware/glance.git
     $ cd Glance
     ```
 
     The main repository will be configured as your `origin` remote.
 
-4. Run the setup script to prepare ParaView Glance:
+4. Run the setup script to prepare Glance:
     ```sh
     $ npm install
     ```
@@ -40,7 +40,7 @@ This page documents at a very high level how to contribute to ParaView Glance Vi
     For more information see: [Create a Pull Request]
 
 
-ParaView Glance Viewer uses Github for code review and Travis-CI to test proposed
+Glance uses Github for code review and Travis-CI to test proposed
 patches before they are merged.
 
 Our [DevSite] is used to document features, flesh out designs and host other
@@ -48,7 +48,7 @@ documentation as well as the API. There are also a [forum]
 to coordinate development and to provide support.
 
 
-[Fork ParaView Glance]: https://help.github.com/articles/fork-a-repo/
+[Fork Glance]: https://help.github.com/articles/fork-a-repo/
 [Create a Pull Request]: https://help.github.com/articles/creating-a-pull-request/
-[DevSite]: http://kitware.github.io/Glance
+[DevSite]: http://kitware.github.io/glance
 [forum]: https://discourse.paraview.org/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Introduction
 ============
-[ParaView Glance][] is an open-source, javascript visualization application created by [Kitware][], based on [Visualization Toolkit (VTK)][VTK], and intended to serve as a light-weight companion to [Paraview][].  It is part of
+[Glance][] is an open-source, javascript visualization application created by [Kitware][], based on [Visualization Toolkit (VTK)][VTK], and intended to serve as a light-weight companion to [Paraview][].  It is part of
 the [ParaView Web][] suite of tools.
 
-[ParaView Glance]: https://kitware.github.io/Glance/
+[Glance]: https://kitware.github.io/glance/
 [ParaView Web]: http://www.paraview.org/web
 [ParaView]: http://www.paraview.org
 [VTK]: http://www.vtk.org
@@ -20,26 +20,26 @@ Learning Resources
 
 * Commercial [support][Kitware Support] and [training][Kitware Training] are available from [Kitware][].
 
-* Additional documentation is being created and will be released as it is created on our [documentation pages][ParaView Glance GitHub.io].
+* Additional documentation is being created and will be released as it is created on our [documentation pages][Glance GitHub.io].
 
 [ParaView Discourse]: https://discourse.paraview.org/
 [Kitware Support]: http://www.kitware.com/products/support.html
 [Kitware Training]: http://www.kitware.com/products/protraining.php
-[ParaView Glance GitHub.io]: https://kitware.github.io/Glance/
+[Glance GitHub.io]: https://kitware.github.io/glance/
 
 
 Live Demonstrations
 ===================
 
-As a javascript application, ParaView Glance can be run by pointing any browser at an appropriate URL or loading an HTML file.
+As a javascript application, Glance can be run by pointing any browser at an appropriate URL or loading an HTML file.
 
-Because of ParaView Glance's ease of distribution, the stable and nightly releases of the code on [github][] can be run by visiting the appropriate web page:
+Because of Glance's ease of distribution, the stable and nightly releases of the code on [github][] can be run by visiting the appropriate web page:
 
-Visit these URLs to run the [stable][] and [nightly][] release of ParaView Glance.
+Visit these URLs to run the [stable][] and [nightly][] release of Glance.
 
-[github]: https://github.com/kitware/Glance
-[stable]: https://kitware.github.io/Glance/app
-[nightly]: https://kitware.github.io/Glance/nightly
+[github]: https://github.com/kitware/glance
+[stable]: https://kitware.github.io/glance/app
+[nightly]: https://kitware.github.io/glance/nightly
 
 
 Building
@@ -51,8 +51,8 @@ If you wish to view, enhance, or adapt this application in any way, you can acce
 
 
 ```
-$ git clone https://github.com/Kitware/Glance.git
-$ cd Glance/
+$ git clone https://github.com/Kitware/glance.git
+$ cd glance/
 $ npm install
 $ npm run build
 $ npm run dev
@@ -89,19 +89,19 @@ $ npx itk-js build itk/
 Reporting Bugs and Making Contributions
 =======================================
 
-If you have found a bug or have a suggestion for improving ParaView Glance:
+If you have found a bug or have a suggestion for improving Glance:
 
 1. If you have source code to contribute, please fork the github repository into your own github account, create a branch with your changes, and then create a merge request with the main repo.
 
-2. If you have a bug to report or a feature to request, please open an entry in the [ParaView Glance Issue Tracker][].
+2. If you have a bug to report or a feature to request, please open an entry in the [Glance Issue Tracker][].
 
-[ParaView Glance Issue Tracker]: https://github.com/kitware/Glance/issues
+[Glance Issue Tracker]: https://github.com/kitware/glance/issues
 
 
 License
 =======
 
-ParaView Glance is distributed under the OSI-approved BSD 3-clause License.  See [COPYRIGHT][] and [LICENSE][] for details. For additional licenses, refer to [ParaView Licenses][].
+Glance is distributed under the OSI-approved BSD 3-clause License.  See [COPYRIGHT][] and [LICENSE][] for details. For additional licenses, refer to [ParaView Licenses][].
 
 [COPYRIGHT]: COPYRIGHT
 [LICENSE]: LICENSE

--- a/documentation/config.js
+++ b/documentation/config.js
@@ -1,15 +1,15 @@
 module.exports = {
-  baseUrl: '/Glance',
+  baseUrl: '/glance',
   work: './build-tmp',
   config: {
-    title: 'ParaView Glance',
+    title: 'Glance',
     description: '"The Web Viewer for your data"',
     subtitle: '"Enable visualization on any computer."',
     author: 'Kitware Inc.',
     timezone: 'UTC',
-    url: 'https://kitware.github.io/Glance',
-    root: '/Glance/',
-    github: 'kitware/Glance',
+    url: 'https://kitware.github.io/glance',
+    root: '/glance/',
+    github: 'kitware/glance',
     google_analytics: 'UA-90338862-10',
   },
   copy: [

--- a/documentation/content/doc/index.md
+++ b/documentation/content/doc/index.md
@@ -1,17 +1,17 @@
-title: What is ParaView Glance?
+title: What is Glance?
 ----
 
-ParaView Glance is a light-weight, open-source, web application developed at Kitware for visualizing volumetric images, molecular structures, geometric objects, and point clouds.
+Glance is a light-weight, open-source, web application developed at Kitware for visualizing volumetric images, molecular structures, geometric objects, and point clouds.
 
 ![Welcome](../gallery/01-glance-welcome.jpg)
 
-As part of the ParaView platform, it is intended to allow users to quickly __glance__ at their small to medium size data.  Ultimately, ParaView Glance is intended to help you:
+As part of the ParaView platform, it is intended to allow users to quickly __glance__ at their small to medium size data.  Ultimately, Glance is intended to help you:
 
 1. quickly view your data on your computer.  It launches quickly and supports a wide variety of data formats so that you can quickly look at the most recent results from a new algorithm you are developing or visually confirm the contents of a data file on your drive.
 
-2. review items-of-interest on [Girder]. Imagine that you have reviewed a large collection of data on Girder, and you have narrowed your search to two interesting items that you want to explore more closely.  Via an optional Girder module, ParaViewGlance can be associated with appropriate types of data items and launched to download and view items of interest with minimal interaction (a single click per item), minimal delay (requiring only the time to transfer the data to your machine), and no need to explicitly install an application or run a dedicated server (ParaViewGlance is a stand-alone, JavaScript+WebAssembly application).
+2. review items-of-interest on [Girder]. Imagine that you have reviewed a large collection of data on Girder, and you have narrowed your search to two interesting items that you want to explore more closely.  Via an optional Girder module, Glance can be associated with appropriate types of data items and launched to download and view items of interest with minimal interaction (a single click per item), minimal delay (requiring only the time to transfer the data to your machine), and no need to explicitly install an application or run a dedicated server (Glance is a stand-alone, JavaScript+WebAssembly application).
 
-3. develop new applications involving VTK.js and ITK.js. ParaView Glance has been architected to be a highly customizable platform.  It can be used as a basis for creating stand-alone web-based applications, desktop applications via Electron, and web-based systems that involve services from [ParaViewWeb] and/or [Resonant].
+3. develop new applications involving VTK.js and ITK.js. Glance has been architected to be a highly customizable platform.  It can be used as a basis for creating stand-alone web-based applications, desktop applications via Electron, and web-based systems that involve services from [ParaViewWeb] and/or [Resonant].
 
 
 [Girder]: http://resonant.kitware.com

--- a/documentation/content/doc/loading_files.md
+++ b/documentation/content/doc/loading_files.md
@@ -1,29 +1,29 @@
 title: Loading Files
 ----
 
-The most straightfoward way to load files into ParaView Glance is to hit the "Open" button on the top-right toolbar, or by typing "Ctrl+O" on the keyboard. To complement different use-cases, there are a few other ways to open files.
+The most straightfoward way to load files into Glance is to hit the "Open" button on the top-right toolbar, or by typing "Ctrl+O" on the keyboard. To complement different use-cases, there are a few other ways to open files.
 
 ## Automatic Remote File Loading via URL
 
-If the data is remote, ParaView Glance can automatically load the data upon startup. ParaView Glance supports two query parameters: `name` and `url`. When given a name and url, Glance will load the data from `url` and name it as the given `name`. As an example, take the dataset `diskout.vtp`, located at address https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download. The full URL to load the data at startup is as follows:
+If the data is remote, Glance can automatically load the data upon startup. Glance supports two query parameters: `name` and `url`. When given a name and url, Glance will load the data from `url` and name it as the given `name`. As an example, take the dataset `diskout.vtp`, located at address https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download. The full URL to load the data at startup is as follows:
 
 ```
-https://kitware.github.io/Glance/app/?name=diskout.vtp&url=https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download
+https://kitware.github.io/glance/app/?name=diskout.vtp&url=https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download
 ```
 
-You can try out this link here: [diskout.vtp](https://kitware.github.io/Glance/app/?name=diskout.vtp&url=https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download)
+You can try out this link here: [diskout.vtp](https://kitware.github.io/glance/app/?name=diskout.vtp&url=https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download)
 
 In order to load multiple remote files at once on startup, wrap the query parameters in square brackets like so:
 
 ```
-https://kitware.github.io/Glance/app/?name=[diskout.vtp,cow.vtp]&url=[https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download,https://data.kitware.com/api/v1/file/5afd936e8d777f15ebe1b4ea/download]
+https://kitware.github.io/glance/app/?name=[diskout.vtp,cow.vtp]&url=[https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download,https://data.kitware.com/api/v1/file/5afd936e8d777f15ebe1b4ea/download]
 ```
 
-You can try out this link here: [diskout.vtp and cow.vtp](https://kitware.github.io/Glance/app/?name=[diskout.vtp,cow.vtp]&url=[https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download,https://data.kitware.com/api/v1/file/5afd936e8d777f15ebe1b4ea/download])
+You can try out this link here: [diskout.vtp and cow.vtp](https://kitware.github.io/glance/app/?name=[diskout.vtp,cow.vtp]&url=[https://data.kitware.com/api/v1/item/59de9de58d777f31ac641dc5/download,https://data.kitware.com/api/v1/file/5afd936e8d777f15ebe1b4ea/download])
 
 ## Loading data from Girder
 
-[Girder](https://girder.readthedocs.io/en/stable/) is an extensible data-management platform designed to store, retrieve, and run tasks on a wide variety of data. ParaView Glance supports loading data from Girder, both via remote files via the URL and via a built-in Girder browser. This section will cover the latter, as the former is covered by the section above.
+[Girder](https://girder.readthedocs.io/en/stable/) is an extensible data-management platform designed to store, retrieve, and run tasks on a wide variety of data. Glance supports loading data from Girder, both via remote files via the URL and via a built-in Girder browser. This section will cover the latter, as the former is covered by the section above.
 
 ![Girder Integration](../gallery/23-girder-integration.png)
 
@@ -43,4 +43,4 @@ When saving Glance state, your data is saved along with the application state. T
 
 For remote files, Glance is smart enough to not save a copy of your dataset in the state file. For instance, if Glance had a remote URL file and a Girder file saved, Glance will automatically recognize that and only save a link to those datasets. That way, the generated state file does not contain a copy of your datasets, keeping the state file small.
 
-If you have Glance state files that are either remote or on Girder, you can load them using the techniques outlined above! Glance will restore with whatever state file you provide, whether it be from some web server or from Girder. This means you can also load Glance state files automatically via the URL, so long as the URL query parameters point to a `*.glance` file. Here is an example that loads `202-t.glance`, one of the samples found on the ParaView Glance landing page: [202-t.glance](https://kitware.github.io/Glance/app/?name=202-t.glance&url=https://raw.githubusercontent.com/Kitware/Glance/master/data/202-t.glance).
+If you have Glance state files that are either remote or on Girder, you can load them using the techniques outlined above! Glance will restore with whatever state file you provide, whether it be from some web server or from Girder. This means you can also load Glance state files automatically via the URL, so long as the URL query parameters point to a `*.glance` file. Here is an example that loads `202-t.glance`, one of the samples found on the Glance landing page: [202-t.glance](https://kitware.github.io/glance/app/?name=202-t.glance&url=https://raw.githubusercontent.com/Kitware/glance/master/data/202-t.glance).

--- a/documentation/content/gallery/index.md
+++ b/documentation/content/gallery/index.md
@@ -13,24 +13,24 @@ title: Gallery
 </style>
 
 <div class="gallery">
-<a href="./01-glance-welcome.jpg"><img alt="ParaView Glance - Welcome page" src="./01-glance-welcome.jpg"></a>
-<a href="./02-glance-about.jpg"><img alt="ParaView Glance - About" src="./02-glance-about.jpg"></a>
-<a href="./03-glance-sample-datasets.jpg"><img alt="ParaView Glance - Sample Datasets" src="./03-glance-sample-datasets.jpg"></a>
-<a href="./04-glance-sample-datasets-hover.jpg"><img alt="ParaView Glance - Sample Datasets" src="./04-glance-sample-datasets-hover.jpg"></a>
-<a href="./13-glance-vessel.jpg"><img alt="ParaView Glance - Flow in Vessel visualization" src="./13-glance-vessel.jpg"></a>
-<a href="./15-single-pin.jpg"><img alt="ParaView Glance - Mixing van simluation" src="./15-single-pin.jpg"></a>
-<a href="./16-glance-unc-powerplant.jpg"><img alt="ParaView Glance - UNC Power plant" src="./16-glance-unc-powerplant.jpg"></a>
-<a href="./14-glance-reactor-mesh.jpg"><img alt="ParaView Glance - Nuclear reactor mesh" src="./14-glance-reactor-mesh.jpg"></a>
-<a href="./21-molecule_screenshot.jpg"><img alt="ParaView Glance - PDB Reader / Molecule visualization" src="./21-molecule_screenshot.jpg"></a>
-<a href="./22-molecule_screenshot_overview.jpg"><img alt="ParaView Glance - PDB Reader / Molecule visualization" src="./22-molecule_screenshot_overview.jpg"></a>
-<a href="./05-skull-quad-crop.jpg"><img alt="ParaView Glance - Quad View" src="./05-skull-quad-crop.jpg"></a>
-<a href="./06-skull-screenshot.jpg"><img alt="ParaView Glance - Screenshot overlay" src="./06-skull-screenshot.jpg"></a>
-<a href="./07-skull-quad-fullscreen.jpg"><img alt="ParaView Glance - Fullscreen" src="./07-skull-quad-fullscreen.jpg"></a>
-<a href="./10-skull-split-fullscreen.jpg"><img alt="ParaView Glance - Slit View fullscreen" src="./10-skull-split-fullscreen.jpg"></a>
-<a href="./17-medical-split-view.jpg"><img alt="ParaView Glance - Torso" src="./17-medical-split-view.jpg"></a>
-<a href="./18-foot-quad.jpg"><img alt="ParaView Glance - Foot" src="./18-foot-quad.jpg"></a>
-<a href="./19-tooth.jpg"><img alt="ParaView Glance - Tooth" src="./19-tooth.jpg"></a>
-<a href="./20-Head_MRI_CISS_quad.jpg"><img alt="ParaView Glance - Head" src="./20-Head_MRI_CISS_quad.jpg"></a>
-<a href="./11-glance-earth.jpg"><img alt="ParaView Glance - Earth" src="./11-glance-earth.jpg"></a>
-<a href="./12-glance-earth-fullscreen.jpg"><img alt="ParaView Glance - Earth" src="./12-glance-earth-fullscreen.jpg"></a>
+<a href="./01-glance-welcome.jpg"><img alt="Glance - Welcome page" src="./01-glance-welcome.jpg"></a>
+<a href="./02-glance-about.jpg"><img alt="Glance - About" src="./02-glance-about.jpg"></a>
+<a href="./03-glance-sample-datasets.jpg"><img alt="Glance - Sample Datasets" src="./03-glance-sample-datasets.jpg"></a>
+<a href="./04-glance-sample-datasets-hover.jpg"><img alt="Glance - Sample Datasets" src="./04-glance-sample-datasets-hover.jpg"></a>
+<a href="./13-glance-vessel.jpg"><img alt="Glance - Flow in Vessel visualization" src="./13-glance-vessel.jpg"></a>
+<a href="./15-single-pin.jpg"><img alt="Glance - Mixing van simluation" src="./15-single-pin.jpg"></a>
+<a href="./16-glance-unc-powerplant.jpg"><img alt="Glance - UNC Power plant" src="./16-glance-unc-powerplant.jpg"></a>
+<a href="./14-glance-reactor-mesh.jpg"><img alt="Glance - Nuclear reactor mesh" src="./14-glance-reactor-mesh.jpg"></a>
+<a href="./21-molecule_screenshot.jpg"><img alt="Glance - PDB Reader / Molecule visualization" src="./21-molecule_screenshot.jpg"></a>
+<a href="./22-molecule_screenshot_overview.jpg"><img alt="Glance - PDB Reader / Molecule visualization" src="./22-molecule_screenshot_overview.jpg"></a>
+<a href="./05-skull-quad-crop.jpg"><img alt="Glance - Quad View" src="./05-skull-quad-crop.jpg"></a>
+<a href="./06-skull-screenshot.jpg"><img alt="Glance - Screenshot overlay" src="./06-skull-screenshot.jpg"></a>
+<a href="./07-skull-quad-fullscreen.jpg"><img alt="Glance - Fullscreen" src="./07-skull-quad-fullscreen.jpg"></a>
+<a href="./10-skull-split-fullscreen.jpg"><img alt="Glance - Slit View fullscreen" src="./10-skull-split-fullscreen.jpg"></a>
+<a href="./17-medical-split-view.jpg"><img alt="Glance - Torso" src="./17-medical-split-view.jpg"></a>
+<a href="./18-foot-quad.jpg"><img alt="Glance - Foot" src="./18-foot-quad.jpg"></a>
+<a href="./19-tooth.jpg"><img alt="Glance - Tooth" src="./19-tooth.jpg"></a>
+<a href="./20-Head_MRI_CISS_quad.jpg"><img alt="Glance - Head" src="./20-Head_MRI_CISS_quad.jpg"></a>
+<a href="./11-glance-earth.jpg"><img alt="Glance - Earth" src="./11-glance-earth.jpg"></a>
+<a href="./12-glance-earth-fullscreen.jpg"><img alt="Glance - Earth" src="./12-glance-earth-fullscreen.jpg"></a>
 </div>

--- a/documentation/content/index.pug
+++ b/documentation/content/index.pug
@@ -5,7 +5,7 @@ comments: false
 ---
 
 div#intro-get-started-wrap
-  a(href="/Glance/app", id="intro-get-started-link") Try out ParaView Glance (Stable)
+  a(href="/glance/app", id="intro-get-started-link") Try out Glance (Stable)
     br
     br
     img(style="padding-left: 25px",src="https://img.shields.io/badge/npm package-4.9.4-green.svg")
@@ -16,13 +16,13 @@ ul#intro-feature-list(style="position:relative;top:-50px;")
       .intro-feature-icon
         i.fa.fa-cloud-download
       h3.intro-feature-title
-        a(href="https://github.com/kitware/Glance").link Releases
+        a(href="https://github.com/kitware/glance").link Releases
       p.intro-feature-desc
-        | ParaView Glance is a general purpose standalone Web application that
+        | Glance is a general purpose standalone Web application that
         | can be used to visualize many data types. It is also a great framework
         | for building custom viewers on the web which can involve remote services.
         | You can follow the progress of it by running our
-        a(href="/Glance/nightly").link  latest version.
+        a(href="/glance/nightly").link  latest version.
 
   li.intro-feature-wrap
     .intro-feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Glance",
+  "name": "glance",
   "version": "0.0.0-semantically-release",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "Glance",
+      "name": "glance",
       "version": "0.0.0-semantically-release",
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Glance",
+  "name": "glance",
   "version": "0.0.0-semantically-release",
   "description": "Web application for Visualizing Scientific and Medical datasets",
   "keywords": [
@@ -16,13 +16,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kitware/Glance.git"
+    "url": "https://github.com/kitware/glance.git"
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/kitware/Glance/issues"
+    "url": "https://github.com/kitware/glance/issues"
   },
-  "homepage": "https://github.com/kitware/Glance",
+  "homepage": "https://github.com/kitware/glance",
   "scripts": {
     "validate": "prettier --config ./prettier.config.js --list-different \"src/**/*.js\"",
     "reformat": "prettier --config ./prettier.config.js --write \"src/**/*.js\"",

--- a/src/components/core/AboutBox/template.html
+++ b/src/components/core/AboutBox/template.html
@@ -9,7 +9,7 @@
   </v-card-title>
   <v-card-text>
     <p class="body-1">
-      <a rel="noopener noreferrer" target="_blank" href="https://kitware.github.io/Glance/">Glance</a>
+      <a rel="noopener noreferrer" target="_blank" href="https://kitware.github.io/glance/">Glance</a>
       is an open-source web application developed at
       <a rel="noopener noreferrer" target="_blank" href="https://www.kitware.com/">Kitware</a>
       for visualizing volumetric images, molecular structures, geometric
@@ -24,11 +24,11 @@
     <ul class="ml-5">
       <li class="body-1">
         <span>Here is our</span>
-        <a rel="noopener noreferrer" target="_blank" href="https://kitware.github.io/Glance/doc/">documentation</a>.
+        <a rel="noopener noreferrer" target="_blank" href="https://kitware.github.io/glance/doc/">documentation</a>.
       </li>
       <li class="body-1">
         <span>We are open source!</span>
-        <a rel="noopener noreferrer" target="_blank" href="https://github.com/Kitware/Glance">Code is on Github</a>.
+        <a rel="noopener noreferrer" target="_blank" href="https://github.com/Kitware/glance">Code is on Github</a>.
       </li>
       <li class="body-1">
         <span>Current version: {{version}}</span>
@@ -48,7 +48,7 @@
       </v-flex>
       <v-flex xs4>
         <div>&nbsp;</div>
-        <a rel="noopener noreferrer" target="_blank" href="http://insightsoftwareconsortium.github.io/itk-js/">
+        <a rel="noopener noreferrer" target="_blank" href="http://insightsoftwareconsortium.github.io/itk-wasm/">
           <svg-icon icon="itkjs" :class="$style.aboutIcon" />
         </a>
       </v-flex>

--- a/src/components/core/Landing/template.html
+++ b/src/components/core/Landing/template.html
@@ -8,7 +8,7 @@
         >
           <v-card flat dark color="transparent">
             <v-card-title class="display-1 text-center pv-break-word">
-              Visualize your data with ParaView Glance
+              Visualize your data with Kitware Glance
             </v-card-title>
             <v-card-text>
               A general purpose standalone web application by
@@ -96,7 +96,7 @@
   <v-footer class="d-flex flex-column" height="48px" color="transparent">
     <div class="mb-2 text-center grey--text text--darken-2">
       <div>&copy; {{ new Date().getFullYear() }} — Kitware, Inc.</div>
-      <div>ParaView Glance ({{version}})</div>
+      <div>Glance ({{version}})</div>
     </div>
   </v-footer>
 </div>

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="google" value="notranslate">
-    <title>ParaView Glance</title>
+    <title>Kitware Glance</title>
     <meta name="description" content="Data Viewer in a browser">
     <link inline rel="icon" type="image/png" href="ParaView.png">
     <style type="text/css">


### PR DESCRIPTION
Renames ParaView Glance to Glance, and preps for renaming the repo from "Glance" to "glance".

FYI @jcfr 