### PR TITLE
fix(SliceControl): guard against no min/max domain

### DIFF
--- a/src/components/controls/SliceControl/script.js
+++ b/src/components/controls/SliceControl/script.js
@@ -31,11 +31,12 @@ function generateSetGetSliceDomain(name) {
   return {
     set() {},
     get() {
-      return {
-        ...this.domains[name],
-        min: Math.floor(this.domains[name].min),
-        max: Math.floor(this.domains[name].max),
-      };
+      const domain = { ...this.domains[name] };
+      if (domain && 'min' in domain && 'max' in domain) {
+        domain.min = Math.floor(domain.min);
+        domain.max = Math.floor(domain.max);
+      }
+      return domain;
     },
   };
 }


### PR DESCRIPTION
Partially addresses #450, restoring the orientation marker.