### PR TITLE
fix(painting): Fix painting tool

### DIFF
--- a/src/components/tools/PaintTool/script.js
+++ b/src/components/tools/PaintTool/script.js
@@ -446,7 +446,7 @@ export default {
       );
       // representation is in XYZ, not IJK, so slice is in world space
       position[view.getAxis()] = representation.getSlice();
-      manipulator.setOrigin(position);
+      manipulator.setHandleOrigin(position);
     },
     enablePainting() {
       const paintProxy = this.$proxyManager.createProxy('Widgets', 'Paint');


### PR DESCRIPTION
'manipulator' object does not have 'setOrigin'. 'setHandleOrigin' should be used instead.

Fixes #453 