### PR TITLE
fix(fileLoader): incorrect return location

### DIFF
--- a/src/store/fileLoader.js
+++ b/src/store/fileLoader.js
@@ -370,8 +370,8 @@ export default ({ proxyManager, girder }) => ({
                 index: fileIndex,
                 error,
               });
+              return ret;
             }
-            return ret;
           }
         }
 


### PR DESCRIPTION
`return ret` is in the wrong spot, resulting in a for loop that iterates exactly once.