### PR TITLE
Add support for camera with LPS mode

### DIFF
--- a/src/components/core/Datasets/script.js
+++ b/src/components/core/Datasets/script.js
@@ -112,6 +112,7 @@ export default {
       }
 
       this.datasets = sources.map((s) => s.getProxyId());
+      this.$store.dispatch('views/updateMasterSourceId', this.datasets);
     },
     getSourceName(sourceId) {
       const proxy = this.$proxyManager.getProxyById(sourceId);

--- a/src/components/core/VtkView/constants.js
+++ b/src/components/core/VtkView/constants.js
@@ -1,18 +1,13 @@
 export const DEFAULT_VIEW_TYPE = 'View3D:default';
 
-export const VIEW_TYPES = [
-  { text: '3D', value: 'View3D:default' },
-  { text: 'Orientation Y', value: 'View2D_Y:y' },
-  { text: 'Orientation X', value: 'View2D_X:x' },
-  { text: 'Orientation Z', value: 'View2D_Z:z' },
-];
+export const DEFAULT_AXIS_PRESET = 'default';
 
-export const VIEW_TYPES_LPS = [
-  { text: '3D', value: 'View3D:default' },
-  { text: 'Sagittal', value: 'View2D_Y:y' },
-  { text: 'Coronal', value: 'View2D_X:x' },
-  { text: 'Axial', value: 'View2D_Z:z' },
-];
+export const VIEW_TYPE_VALUES = {
+  default: 'View3D:default',
+  x: 'View2D_X:x',
+  y: 'View2D_Y:y',
+  z: 'View2D_Z:z',
+};
 
 /* eslint-disable  no-template-curly-in-string */
 export const CURSOR_ANNOTATIONS = {
@@ -26,25 +21,22 @@ export const ANNOTATIONS = {
 };
 /* eslint-enable no-template-curly-in-string */
 
-export const VIEW_ORIENTATIONS = {
-  default: {
-    axis: 1,
-    orientation: -1,
-    viewUp: [0, 0, 1],
-  },
-  x: {
-    axis: 0,
-    orientation: 1,
-    viewUp: [0, 0, 1],
-  },
-  y: {
-    axis: 1,
-    orientation: -1,
-    viewUp: [0, 0, 1],
-  },
-  z: {
-    axis: 2,
-    orientation: -1,
-    viewUp: [0, -1, 0],
-  },
+export const DEFAULT_VIEW_TYPES = {
+  [VIEW_TYPE_VALUES.default]: '3D',
+  [VIEW_TYPE_VALUES.x]: 'Orientation X',
+  [VIEW_TYPE_VALUES.y]: 'Orientation Y',
+  [VIEW_TYPE_VALUES.z]: 'Orientation Z',
 };
+
+export const DEFAULT_LPS_VIEW_TYPES = {
+  [VIEW_TYPE_VALUES.default]: '3D',
+  [VIEW_TYPE_VALUES.x]: 'Sagittal',
+  [VIEW_TYPE_VALUES.y]: 'Coronal',
+  [VIEW_TYPE_VALUES.z]: 'Axial',
+};
+
+export const DEFAULT_VIEW_ORIENTATION = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+];

--- a/src/components/core/VtkView/script.js
+++ b/src/components/core/VtkView/script.js
@@ -4,14 +4,13 @@ import { Breakpoints } from 'paraview-glance/src/constants';
 import {
   ANNOTATIONS,
   DEFAULT_VIEW_TYPE,
-  VIEW_TYPES,
-  VIEW_TYPES_LPS,
-  VIEW_ORIENTATIONS,
 } from 'paraview-glance/src/components/core/VtkView/constants';
 
 import PalettePicker from 'paraview-glance/src/components/widgets/PalettePicker';
 import ToolbarSheet from 'paraview-glance/src/components/core/ToolbarSheet';
 import { BACKGROUND } from 'paraview-glance/src/components/core/VtkView/palette';
+
+import { updateViewOrientationFromBasisAndAxis } from 'paraview-glance/src/utils';
 
 const ROTATION_STEP = 2;
 
@@ -69,6 +68,15 @@ export default {
       axisPreset(state) {
         return state.axisPreset;
       },
+      viewOrientation(state) {
+        return state.viewOrientation;
+      },
+      viewTypeItems(state) {
+        return Object.entries(state.viewTypes).map(([viewType, text]) => ({
+          text,
+          value: viewType,
+        }));
+      },
     }),
     ...mapGetters(['cameraViewPoints']),
     type() {
@@ -79,9 +87,6 @@ export default {
     },
     orientationLabels() {
       return this.axisPreset === 'lps' ? ['L', 'P', 'S'] : ['X', 'Y', 'Z'];
-    },
-    viewTypes() {
-      return this.axisPreset === 'lps' ? VIEW_TYPES_LPS : VIEW_TYPES;
     },
     smallScreen() {
       return this.$vuetify.breakpoint.width < Breakpoints.md;
@@ -250,8 +255,12 @@ export default {
     updateOrientation(mode) {
       if (this.view && !this.inAnimation) {
         this.inAnimation = true;
-        const { axis, orientation, viewUp } = VIEW_ORIENTATIONS[mode];
-        this.view.updateOrientation(axis, orientation, viewUp, 100).then(() => {
+        updateViewOrientationFromBasisAndAxis(
+          this.view,
+          this.viewOrientation,
+          mode,
+          this.type === 'View3D' ? 100 : 0
+        ).then(() => {
           this.inAnimation = false;
         });
       }

--- a/src/components/core/VtkView/template.html
+++ b/src/components/core/VtkView/template.html
@@ -136,7 +136,7 @@
           flat
           hide-details
           :class="$style.viewTypeSelector"
-          :items="viewTypes"
+          :items="viewTypeItems"
           :value="viewType"
           @change="changeViewType"
         />

--- a/src/store/views.js
+++ b/src/store/views.js
@@ -4,12 +4,20 @@ import WidgetManagerConstants from '@kitware/vtk.js/Widgets/Core/WidgetManager/C
 
 import {
   DEFAULT_VIEW_TYPE,
-  VIEW_TYPES,
-  VIEW_ORIENTATIONS,
+  DEFAULT_AXIS_PRESET,
+  VIEW_TYPE_VALUES,
+  DEFAULT_VIEW_TYPES,
+  DEFAULT_LPS_VIEW_TYPES,
+  DEFAULT_VIEW_ORIENTATION,
 } from 'paraview-glance/src/components/core/VtkView/constants';
 import { DEFAULT_BACKGROUND } from 'paraview-glance/src/components/core/VtkView/palette';
 
-import { remapIdValues, wrapMutationAsAction } from 'paraview-glance/src/utils';
+import {
+  remapIdValues,
+  wrapMutationAsAction,
+  getLPSDirections,
+  updateViewOrientationFromBasisAndAxis,
+} from 'paraview-glance/src/utils';
 
 const { CaptureOn } = WidgetManagerConstants;
 
@@ -21,7 +29,7 @@ export default ({ proxyManager }) => ({
     backgroundColors: {}, // viewType -> bg
     globalBackgroundColor: DEFAULT_BACKGROUND,
     axisType: 'arrow',
-    axisPreset: 'default',
+    axisPreset: DEFAULT_AXIS_PRESET,
     axisVisible: true,
     annotationOpacity: 1,
     interactionStyle3D: '3D',
@@ -30,8 +38,14 @@ export default ({ proxyManager }) => ({
     // If null, it will be calculated and set on first use
     firstPersonMovementSpeed: null,
     maxTextureLODSize: 50000, // Units are in KiB
-    viewOrder: VIEW_TYPES.map((v) => v.value),
+    viewOrder: Object.values(VIEW_TYPE_VALUES),
     visibleCount: 1,
+    // a basis in column-major order (list of 3 vectors): number[3][3]
+    viewOrientation: DEFAULT_VIEW_ORIENTATION,
+    // for each view type, the corresponding text to display { viewType: text }
+    viewTypes: DEFAULT_VIEW_TYPES,
+    masterSourceId: null, // null or string
+    previousConfigurationPreset: null, // null or string, can only be set to a string
   },
   mutations: {
     setGlobalBackground(state, background) {
@@ -66,6 +80,18 @@ export default ({ proxyManager }) => ({
     mapViewTypeToId(state, { viewType, viewId }) {
       Vue.set(state.viewTypeToId, viewType, viewId);
     },
+    setViewTypes(state, types) {
+      state.viewTypes = types;
+    },
+    setViewOrientation(state, orientation) {
+      state.viewOrientation = orientation;
+    },
+    setMasterSourceId(state, { sourceId }) {
+      state.masterSourceId = sourceId;
+    },
+    setPreviousConfigurationPreset(state, preset) {
+      state.previousConfigurationPreset = preset;
+    },
     changeBackground(state, { viewType, color }) {
       state.backgroundColors[viewType] = color;
     },
@@ -97,8 +123,11 @@ export default ({ proxyManager }) => ({
           const view = proxyManager.createProxy('Views', type, { name });
 
           // Update orientation
-          const { axis, orientation, viewUp } = VIEW_ORIENTATIONS[name];
-          view.updateOrientation(axis, orientation, viewUp);
+          updateViewOrientationFromBasisAndAxis(
+            view,
+            state.viewOrientation,
+            name
+          );
 
           // set background to transparent
           view.setBackground(0, 0, 0, 0);
@@ -167,11 +196,86 @@ export default ({ proxyManager }) => ({
       });
       commit('setAxisType', axisType);
     },
-    setAxisPreset({ commit }, axisPreset) {
+    setAxisPreset({ commit, dispatch }, axisPreset) {
       proxyManager.getViews().forEach((view) => {
         view.setPresetToOrientationAxes(axisPreset);
       });
       commit('setAxisPreset', axisPreset);
+      dispatch('configureViewOrientationAndTypes');
+    },
+    setViewOrientation({ commit, state }, orientation) {
+      commit('setViewOrientation', orientation);
+      Object.entries(state.viewTypeToId).forEach(([viewType, viewId]) => {
+        const view = proxyManager.getProxyById(viewId);
+        const [type, name] = viewType.split(':');
+        updateViewOrientationFromBasisAndAxis(
+          view,
+          orientation,
+          name,
+          type === 'View3D' ? 100 : 0
+        );
+      });
+    },
+    setViewTypes({ commit }, viewTypes) {
+      commit('setViewTypes', viewTypes);
+    },
+    configureViewOrientationAndTypes({ commit, dispatch, state }) {
+      if (state.axisPreset === 'lps') {
+        const masterSource =
+          state.masterSourceId &&
+          proxyManager.getProxyById(state.masterSourceId);
+        if (masterSource?.getDataset().isA('vtkImageData')) {
+          // lps mode with a master volume
+          const directionMatrix = masterSource.getDataset().getDirection();
+          const lpsDirections = getLPSDirections(directionMatrix);
+          const axisToXYZ = ['x', 'y', 'z'];
+          const viewTypes = {
+            [VIEW_TYPE_VALUES.default]: '3D',
+            [VIEW_TYPE_VALUES[axisToXYZ[lpsDirections.l.axis]]]: 'Sagittal',
+            [VIEW_TYPE_VALUES[axisToXYZ[lpsDirections.p.axis]]]: 'Coronal',
+            [VIEW_TYPE_VALUES[axisToXYZ[lpsDirections.s.axis]]]: 'Axial',
+          };
+          const viewOrientation = [
+            lpsDirections.l.vector,
+            lpsDirections.p.vector,
+            lpsDirections.s.vector,
+          ];
+          dispatch('setViewTypes', viewTypes);
+          dispatch('setViewOrientation', viewOrientation);
+        } else if (state.previousConfigurationPreset !== 'lps') {
+          // lps mode but no master volume and previous configuration wasn't lps
+          dispatch('setViewTypes', DEFAULT_LPS_VIEW_TYPES);
+          dispatch('setViewOrientation', DEFAULT_VIEW_ORIENTATION);
+        }
+      } else {
+        // Not in lps mode
+        dispatch('setViewTypes', DEFAULT_VIEW_TYPES);
+        dispatch('setViewOrientation', DEFAULT_VIEW_ORIENTATION);
+      }
+      commit('setPreviousConfigurationPreset', state.axisPreset);
+    },
+    updateMasterSourceId({ dispatch, state }, datasets) {
+      const hiddenDatasets = proxyManager
+        .getRepresentations()
+        .filter((r) => !r.isVisible())
+        .map((r) => r.getInput().getProxyId());
+      const fullyVisibleDatasets = datasets.filter(
+        (dataset) => !hiddenDatasets.includes(dataset)
+      );
+
+      if (!fullyVisibleDatasets.includes(state.masterSourceId)) {
+        if (fullyVisibleDatasets.length === 0) {
+          dispatch('setMasterSourceId', { sourceId: null });
+        } else {
+          dispatch('setMasterSourceId', { sourceId: fullyVisibleDatasets[0] });
+        }
+      }
+    },
+    setMasterSourceId({ commit, dispatch, state }, { sourceId }) {
+      commit('setMasterSourceId', { sourceId });
+      if (state.axisPreset === 'lps') {
+        dispatch('configureViewOrientationAndTypes');
+      }
     },
     setAxisVisible({ commit }, visible) {
       proxyManager.getViews().forEach((view) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { vec3 } from 'gl-matrix';
+
 export function makeSubManager() {
   let currentSub = null;
 
@@ -113,6 +115,151 @@ export function getCropFilter(pxm, proxy) {
   return volRep.getCropFilter();
 }
 
+/**
+ * Function adapted from getLPSDirections lps.ts from VolView.
+ * Associates the column vectors of a 3x3 matrix with the LPS axes.
+ *
+ * For each of the LPS axes, this function returns the associated column index (0, 1, 2)
+ * in the provided 3x3 column-major matrix and the corresponding positive vector.
+ *
+ * Approach:
+ *   - find the max of the direction matrix, ignoring columns and rows marked as done
+ *   - assign the column vector of that max value to the row axis
+ *   - mark that row and column as done
+ *   - continue until all rows and columns are done
+ */
+export function getLPSDirections(directionMatrix) {
+  const axisToLPS = ['l', 'p', 's'];
+  const lpsDirs = {};
+  // Track the rows and columns that have yet to be assigned.
+  const availableCols = [0, 1, 2];
+  const availableRows = [0, 1, 2];
+
+  for (let i = 0; i < 3; i++) {
+    let bestValue = 0;
+    let bestValueLoc = [0, 0]; // col, row
+    let removeIndices = [0, 0]; // indices into availableCols/Rows for deletion
+
+    availableCols.forEach((col, colIdx) => {
+      availableRows.forEach((row, rowIdx) => {
+        const value = directionMatrix[col * 3 + row];
+        if (Math.abs(value) > Math.abs(bestValue)) {
+          bestValue = value;
+          bestValueLoc = [col, row];
+          removeIndices = [colIdx, rowIdx];
+        }
+      });
+    });
+
+    // the row index corresponds to the index of the LPS axis
+    const [col, axis] = bestValueLoc;
+    const axisVector = directionMatrix.slice(col * 3, (col + 1) * 3);
+    const vecSign = Math.sign(bestValue);
+    const posVector = vec3.scale(Array(3), axisVector, vecSign);
+    lpsDirs[axisToLPS[axis]] = {
+      axis: col,
+      vector: posVector,
+    };
+    availableCols.splice(removeIndices[0], 1);
+    availableRows.splice(removeIndices[1], 1);
+  }
+
+  return lpsDirs;
+}
+
+/**
+ * Associate a key of VIEW_TYPE_VALUES to axis index and orientation
+ * for forward and upward vectors.
+ */
+const MODE_TO_AXES = {
+  default: {
+    forwardAxis: 1,
+    forwardOrientation: 1,
+    upwardAxis: 2,
+    upwardOrientation: 1,
+  },
+  x: {
+    forwardAxis: 0,
+    forwardOrientation: 1,
+    upwardAxis: 2,
+    upwardOrientation: 1,
+  },
+  y: {
+    forwardAxis: 1,
+    forwardOrientation: 1,
+    upwardAxis: 2,
+    upwardOrientation: 1,
+  },
+  z: {
+    forwardAxis: 2,
+    forwardOrientation: 1,
+    upwardAxis: 1,
+    upwardOrientation: -1,
+  },
+};
+
+/**
+ * Update the camera view using the given arguments:
+ *  - view which is a vtkViewProxy
+ *  - basis, a list of 3 vec3 defining a basis
+ *  - mode, a key of VIEW_TYPE_VALUES
+ *  - an optional number of animateSteps
+ *
+ * The forward vector is computed from the mode argument.
+ * The upward vector computed from the forward axis.
+ *
+ * This function returns a promise which resolves when the animation is done.
+ */
+export function updateViewOrientationFromBasisAndAxis(
+  view,
+  basis,
+  mode,
+  animateSteps = 0
+) {
+  // Compute forward and upward vectors
+  const { forwardAxis, forwardOrientation, upwardAxis, upwardOrientation } =
+    MODE_TO_AXES[mode];
+  const forwardVector = vec3.scale(
+    Array(3),
+    basis[forwardAxis],
+    forwardOrientation
+  );
+  const upwardVector = vec3.scale(
+    Array(3),
+    basis[upwardAxis],
+    upwardOrientation
+  );
+
+  // Find camera parameters
+  // Adapted from vtkViewProxy.updateOrientation to support arbitrary axis
+  const camera = view.getCamera();
+  const originalPosition = camera.getPosition();
+  const originalViewUp = camera.getViewUp();
+  const originalFocalPoint = camera.getFocalPoint();
+
+  const position = vec3.add(Array(3), originalFocalPoint, forwardVector);
+
+  camera.setPosition(...position);
+  camera.setViewUp(...upwardVector);
+
+  view.resetCamera();
+
+  const destFocalPoint = camera.getFocalPoint();
+  const destPosition = camera.getPosition();
+  const destViewUp = camera.getViewUp();
+
+  camera.setFocalPoint(...originalFocalPoint);
+  camera.setPosition(...originalPosition);
+  camera.setViewUp(...originalViewUp);
+
+  return view.moveCamera(
+    destFocalPoint,
+    destPosition,
+    destViewUp,
+    animateSteps
+  );
+}
+
 export default {
   makeSubManager,
   wrapSub,
@@ -121,4 +268,6 @@ export default {
   remapIdList,
   createRepresentationInAllViews,
   getCropFilter,
+  getLPSDirections,
+  updateViewOrientationFromBasisAndAxis,
 };


### PR DESCRIPTION
Move camera in front of volume in 2D and 3D views

getLPSDirections comes from VolView
Use forwardVector and upwardVector instead of axis, orientation, viewUp when moving the camera
Get these info from a basis (3 vec3) in the view store instead of hardcoding it
Replace VIEW_ORIENTATIONS and VIEW_TYPES with variables in the view store
Introduce the notion of master volume in the view store

Closes #463