### PR TITLE
Bump vtk.js from 28.0.0 to 28.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@girder/components": "3.1.0",
-        "@kitware/vtk.js": "28.0.0",
+        "@kitware/vtk.js": "28.10.2",
         "@linusborg/vue-simple-portal": "0.1.5",
         "itk": "13.1.4",
         "jszip": "3.7.1",
@@ -1974,9 +1974,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@kitware/vtk.js": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-28.0.0.tgz",
-      "integrity": "sha512-QJWZ2xqAlEOBtF53g1uvnvd3qKvwEwJn3L0CEr+s7vkDpNnmkNTBUeLuYOADa3LqUz99zuC865t5KjzXFnvHJg==",
+      "version": "28.10.2",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-28.10.2.tgz",
+      "integrity": "sha512-sGjGKJST+heRdmN6Ta2puMDtShPl5B7j9awRBcssOvQaj5j6bdVAG9NZSHiyFIhkcpR5QMkRN+te5qU0kpWSnQ==",
       "dependencies": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
@@ -29779,9 +29779,9 @@
       }
     },
     "@kitware/vtk.js": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-28.0.0.tgz",
-      "integrity": "sha512-QJWZ2xqAlEOBtF53g1uvnvd3qKvwEwJn3L0CEr+s7vkDpNnmkNTBUeLuYOADa3LqUz99zuC865t5KjzXFnvHJg==",
+      "version": "28.10.2",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-28.10.2.tgz",
+      "integrity": "sha512-sGjGKJST+heRdmN6Ta2puMDtShPl5B7j9awRBcssOvQaj5j6bdVAG9NZSHiyFIhkcpR5QMkRN+te5qU0kpWSnQ==",
       "requires": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "Kitware",
   "dependencies": {
     "@girder/components": "3.1.0",
-    "@kitware/vtk.js": "28.0.0",
+    "@kitware/vtk.js": "28.10.2",
     "@linusborg/vue-simple-portal": "0.1.5",
     "itk": "13.1.4",
     "jszip": "3.7.1",


### PR DESCRIPTION
Bump vtk.js to bring [this fix](https://github.com/Kitware/vtk-js/pull/2909) into glance