### PR TITLE
Use the new getSparseOrthogonalMatrix instead of getLPSDirections

### DIFF
--- a/src/components/core/VtkView/constants.js
+++ b/src/components/core/VtkView/constants.js
@@ -35,8 +35,4 @@ export const DEFAULT_LPS_VIEW_TYPES = {
   [VIEW_TYPE_VALUES.z]: 'Axial',
 };
 
-export const DEFAULT_VIEW_ORIENTATION = [
-  [1, 0, 0],
-  [0, 1, 0],
-  [0, 0, 1],
-];
+export const DEFAULT_VIEW_ORIENTATION = [1, 0, 0, 0, 1, 0, 0, 0, 1];


### PR DESCRIPTION
This avoids redundant code

Replace getLPSDirections with getSparseOrthogonalMatrix
Replace the array of vectors with a matrix