### PR TITLE
feat(girder): allow disabling girder integration entirely

### DIFF
--- a/src/components/core/FileLoader/script.js
+++ b/src/components/core/FileLoader/script.js
@@ -13,6 +13,7 @@ export default {
     DragAndDrop,
     GirderBox,
   },
+  inject: ['girderRest'],
   props: {
     value: {
       type: Boolean,

--- a/src/components/core/FileLoader/template.html
+++ b/src/components/core/FileLoader/template.html
@@ -13,7 +13,7 @@
           <v-container>
             <v-tabs v-model="active_tab">
               <v-tab>Local</v-tab>
-              <v-tab>Girder</v-tab>
+              <v-tab v-if="girderRest">Girder</v-tab>
               <v-tab-item transition="fade-transition">
                 <drag-and-drop
                   enabled
@@ -37,7 +37,7 @@
                   </template>
                 </drag-and-drop>
               </v-tab-item>
-              <v-tab-item transition="fade-transition">
+              <v-tab-item transition="fade-transition" v-if="girderRest">
                 <girder-box />     
               </v-tab-item>
             </v-tabs>

--- a/src/components/tools/MeasurementTools/template.html
+++ b/src/components/tools/MeasurementTools/template.html
@@ -169,10 +169,10 @@
         <template v-else>
           <div class="pt-2 body-1 teal--text text-center">No measurements yet</div>
         </template>
-        <v-btn :disabled="!targetProxy || !girderRest.user" @click="upload">
+        <v-btn :disabled="!targetProxy || !girderRest || !girderRest.user" @click="upload">
           Upload
         </v-btn>
-        <span v-show="!girderRest.user" class="body-2">Log in to upload</span>
+        <span v-show="!girderRest || !girderRest.user" class="body-2">Log in to upload</span>
       </div>
     </v-card>
   </v-container>

--- a/src/components/tools/PaintTool/template.html
+++ b/src/components/tools/PaintTool/template.html
@@ -227,12 +227,12 @@
         </v-list>
       </v-flex>
       <v-btn
-        :disabled="!girderRest.user"
+        :disabled="!girderRest || !girderRest.user"
         @click="upload()"
       >
         Upload
       </v-btn>
-      <span v-show="!girderRest.user" class="body-2">Log in to upload</span>
+      <span v-show="!girderRest || !girderRest.user" class="body-2">Log in to upload</span>
     </v-layout>
   </v-container>
 </div>

--- a/src/girder.js
+++ b/src/girder.js
@@ -6,17 +6,19 @@ import vtkURLExtract from '@kitware/vtk.js/Common/Core/URLExtract';
 // Install the Vue plugin that lets us use the components
 Vue.use(Girder);
 
-// This connects to another server if the VUE_APP_API_ROOT
-// environment variable is set at build-time
-const { girderRoute } = vtkURLExtract.extractURLParameters();
-
-const apiRoot = girderRoute || 'https://data.kitware.com/api/v1';
-
+// URL parameters to change Girder API root URL, or to disable it completely
+const { girderRoute, noGirder } = vtkURLExtract.extractURLParameters();
 // Create the axios-based client to be used for all API requests
-const girderRest = new RestClient({
-  apiRoot,
-});
-girderRest.fetchUser();
+const apiRoot = girderRoute || 'https://data.kitware.com/api/v1';
+const girderRest = noGirder
+  ? undefined
+  : new RestClient({
+      apiRoot,
+    });
+
+if (girderRest) {
+  girderRest.fetchUser();
+}
 
 // This is passed to our Vue instance; it will be available in all components
 const GirderProvider = {


### PR DESCRIPTION
Hi, when exporting a scene to Glance from ParaView, I want to be able to make the HTML file be isolated from the network, and avoid making any network call to external servers. This patch allows disabling the Girder integration entierly when the `noGirder` URL parameter is set. On ParaView's side, if a checkbox is active when creating the Glance export, the URL parameter `noGirder` will be forced onto the page if it is not set.

Please tell me if you see a better implementation of this idea.

cc @mwestphal